### PR TITLE
xcodebuild: Fix code completion for Zsh 5.9 and xcodebuild 14.3.1

### DIFF
--- a/src/_xcodebuild
+++ b/src/_xcodebuild
@@ -53,7 +53,6 @@ _actions() {
 
 _arguments \
   '(-n -dry-run)'{-n,-dry-run}'[Print but do not execute commands]' \
-  '*: :->actions' \
   '-alltargets[Build all targets in the specified project]' \
   '-arch[Architecture to build]:Architecture to build:->archs' \
   '-archivePath[Archive Path]:Archive Path:_directories' \
@@ -83,12 +82,10 @@ _arguments \
   '-usage[Display xcodebuild usage]' \
   '-version[Prints Xcode version]' \
   '-workspace[xcworkspace file]:xcworkspace:->workspaces' \
-  '-xcconfig[xcconfig file]:xcconfig:->xcconfigs'
+  '-xcconfig[xcconfig file]:xcconfig:->xcconfigs' \
+  '*:Build action:_actions'
 
 case "$state" in
-  actions)
-    _actions
-    ;;
   archs)
     archs=($(_archs))
     if [[ $archs != "" ]]; then


### PR DESCRIPTION
Fixes a current bug with the `xcodebuild` completion that breaks completion for arguments (Zsh would print the first set of available arguments, but then also print optional completions and completions that require a specific argument).

This also makes the build action available for completion at arbitrary points in the command (a missing hyphen will trigger the `_actions` completion).